### PR TITLE
Improve shell exit behavior in wakatime.fish

### DIFF
--- a/conf.d/wakatime.fish
+++ b/conf.d/wakatime.fish
@@ -31,5 +31,5 @@ function __register_wakatime_fish_before_exec -e fish_preexec
     set project "Terminal"
   end
 
-  $wakatime_path --write --plugin "$PLUGIN_NAME/$PLUGIN_VERSION" --entity-type app --project "$project" --entity (echo $history[1] | cut -d ' ' -f1) &> /dev/null&
+  $wakatime_path --write --plugin "$PLUGIN_NAME/$PLUGIN_VERSION" --entity-type app --project "$project" --entity (echo $history[1] | cut -d ' ' -f1) &> /dev/null&; disown
 end


### PR DESCRIPTION
### Description
This pull request addresses the issue with the Wakatime integration in the `wakatime.fish` script. The original script had a problem where the shell wouldn't close correctly when the `exit` command was typed due to the missing `disown` for the Wakatime process. This fix ensures a proper shell termination process.

### Changes Made
- Added `disown` after calling the Wakatime plugin to fix shell exit behavior.