### PR TITLE
文字列分割をfish組み込みコマンドを使うように

### DIFF
--- a/conf.d/wakatime.fish
+++ b/conf.d/wakatime.fish
@@ -12,7 +12,7 @@ function __register_wakatime_fish_before_exec -e fish_postexec
   
   set -l exec_command_str
 
-  set exec_command_str (echo $argv | cut -d ' ' -f1)
+  set exec_command_str (string split -f1 ' ' "$argv")
 
   if test "$exec_command_str" = 'exit'
     return 0


### PR DESCRIPTION
fish内で文字列操作可能なので、そちらを使用して外部コマンド依存を減らす (echo, cutがない環境は考えにくいが、bsd等で挙動が変わる可能性等もなくはないので)

https://fishshell.com/docs/current/cmds/string-split.html