### PR TITLE
wakatime-cli (Go版) を優先検出するよう更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 [fish](https://fishshell.com/) plugin for [WakaTime](https://wakatime.com/)
 
-Unofficial script for wakatime tracking in the fish shell.
+Unofficial script that sends each command you run in the fish shell as a heartbeat to [WakaTime](https://wakatime.com/) via [wakatime-cli](https://github.com/wakatime/wakatime-cli).
 
-## Differences from [officially linked scripts](https://wakatime.com/terminal#install-fish)
+> **Note:** WakaTime itself recommends using IDE plugins or the desktop app for accurate coding stats; terminal-based tracking is unofficial. Use this plugin only if you also want command-level activity tracked from your shell.
 
-- Also works with wakatime-cli.
-- Use git information to determine project name.
-- Can be installed as a [fisher](https://github.com/jorgebucaran/fisher) plugin.
+## Features
+
+- Works with [wakatime-cli](https://github.com/wakatime/wakatime-cli) (the official Go-based CLI).
+- Uses git information to determine the project name automatically.
+- Installable as a [fisher](https://github.com/jorgebucaran/fisher) plugin.
 
 ## Getting Started
 
@@ -16,14 +18,31 @@ Unofficial script for wakatime tracking in the fish shell.
 
 - [wakatime-cli](https://github.com/wakatime/wakatime-cli)
 - [fisher](https://github.com/jorgebucaran/fisher)
+- A WakaTime API key configured in `~/.wakatime.cfg` (see [WakaTime account settings](https://wakatime.com/settings/account))
 
 #### wakatime-cli Install
 
-If it does not work, please refer to the [official documentation](https://wakatime.com/terminal).
+Install [wakatime-cli](https://github.com/wakatime/wakatime-cli) (the Go-based CLI) with any of the following methods:
 
-```bash
-curl https://raw.githubusercontent.com/wakatime/vim-wakatime/master/scripts/install_cli.py | python3 -
-```
+- Homebrew (macOS / Linux) — installs `wakatime-cli` onto your `$PATH`:
+
+  ```bash
+  brew install wakatime-cli
+  ```
+
+- Download the latest release binary directly from [wakatime/wakatime-cli releases](https://github.com/wakatime/wakatime-cli/releases) and place it on your `$PATH`.
+
+- Installer script — downloads the prebuilt `wakatime-cli` binary to `~/.wakatime/wakatime-cli`:
+
+  ```bash
+  curl -fsSL https://raw.githubusercontent.com/wakatime/vim-wakatime/refs/heads/master/scripts/install_cli.py | python3 -
+  ```
+
+This plugin looks for wakatime-cli in this order:
+
+1. `wakatime-cli` on your `$PATH` (Homebrew, direct download, etc.)
+2. `~/.wakatime/wakatime-cli` (installer script above)
+3. `wakatime` on your `$PATH` — the legacy Python CLI from [`pip install wakatime`](https://github.com/wakatime/wakatime) (kept only for backward compatibility)
 
 #### fisher Install
 

--- a/conf.d/wakatime.fish
+++ b/conf.d/wakatime.fish
@@ -9,35 +9,35 @@ function __register_wakatime_fish_before_exec -e fish_postexec
   if set -q FISH_WAKATIME_DISABLED
     return 0
   end
-  
-  set -l exec_command_str
 
-  set exec_command_str (string split -f1 ' ' "$argv")
+  set -l exec_command_str (string split -f1 ' ' "$argv")
 
   if test "$exec_command_str" = 'exit'
     return 0
   end
 
   set -l PLUGIN_NAME "ik11235/wakatime.fish"
-  set -l PLUGIN_VERSION "0.0.6"
+  set -l PLUGIN_VERSION "0.0.7"
 
-  set -l project
   set -l wakatime_path
 
-  if type -p wakatime 2>&1 > /dev/null
-    set wakatime_path (type -p wakatime)
-  else if type -p ~/.wakatime/wakatime-cli 2>&1 > /dev/null
-    set wakatime_path (type -p ~/.wakatime/wakatime-cli)
+  if type -q wakatime-cli
+    set wakatime_path (command -v wakatime-cli)
+  else if test -x "$HOME/.wakatime/wakatime-cli"
+    set wakatime_path "$HOME/.wakatime/wakatime-cli"
+  else if type -q wakatime
+    set wakatime_path (command -v wakatime)
   else
-    echo "wakatime command not found. Please read \"https://wakatime.com/terminal\" and install wakatime."
+    echo "wakatime-cli command not found. Please install wakatime-cli from \"https://github.com/wakatime/wakatime-cli\"."
     return 1
   end
 
+  set -l project
   if git rev-parse --is-inside-work-tree &> /dev/null
     set project (basename (git rev-parse --show-toplevel))
   else
     set project "Terminal"
   end
 
-  $wakatime_path --write --plugin "$PLUGIN_NAME/$PLUGIN_VERSION" --entity-type app --project "$project" --entity "$exec_command_str" &> /dev/null&; disown
+  $wakatime_path --write --plugin "$PLUGIN_NAME/$PLUGIN_VERSION" --entity-type app --project "$project" --entity "$exec_command_str" &> /dev/null &; disown
 end


### PR DESCRIPTION
## Summary

- 公式の Go 版 [wakatime-cli](https://github.com/wakatime/wakatime-cli) を最優先で検出するように検出順を変更。Homebrew (`brew install wakatime-cli`) など `$PATH` 上の `wakatime-cli` をそのまま使えるようになります。
- 検出順は `wakatime-cli` (PATH) → `~/.wakatime/wakatime-cli` → legacy `wakatime` (pip 版) の 3 段に整理。
- `~/.wakatime/wakatime-cli` の存在判定を `type -p` から `test -x` に変更（絶対パスに対して挙動が安定する形へ）。
- 公式が terminal プラグインを非推奨にしている `https://wakatime.com/terminal` への誘導を README とエラーメッセージから削除し、wakatime-cli リポジトリ・Homebrew・GitHub Releases・installer script に直接案内するよう書き直し。
- プラグインバージョンを `0.0.6` → `0.0.7` に更新。

## Background

WakaTime 公式の terminal プラグイン案内ページ (`https://wakatime.com/terminal`) は本文中で "Don't use these Terminal plugins. Instead, use the IDE plugins or Desktop apps." と terminal 計測自体を非推奨にしています。一方で本プラグインを使い続けたいユーザー向けに、現行 Go 製 CLI である wakatime-cli を正しく検出できるよう更新しました。

## Test plan

- [x] `fish -n conf.d/wakatime.fish` で構文エラーなし
- [x] Homebrew 経由でインストールされた `/opt/homebrew/bin/wakatime-cli` (`v2.14.2`) が検出されること
- [x] 検出された `wakatime-cli --write --plugin "ik11235/wakatime.fish/0.0.7" --entity-type app --project ... --entity ...` が exit 0 で正常終了すること

Generated with Claude Code